### PR TITLE
Move from classes to structs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,9 @@
 name: Deploy documentation
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
+  release:
+    types: [published]
 
 jobs:
   deploy:
@@ -21,7 +21,7 @@ jobs:
         run: shards install --ignore-crystal-version
 
       - name: "Generate docs"
-        run: crystal docs
+        run: crystal docs --project-name=Decorator --project-version=${GITHUB_REF##*/}
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/shard.yml
+++ b/.github/workflows/shard.yml
@@ -25,10 +25,13 @@ jobs:
 
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
-    container: crystallang/crystal:${{ matrix.crystal_version }}-alpine
 
     steps:
       - uses: actions/checkout@v2
+
+      - uses: oprypin/install-crystal@v1
+        with:
+          crystal: ${{matrix.crystal_version}}
 
       - name: Check format
         run: crystal tool format --check
@@ -49,7 +52,7 @@ jobs:
         if: steps.crystal-cache.outputs.cache-hit != 'true'
         run: shards check || shards install --ignore-crystal-version
 
-      - name: Crystal Ameba Linter
+      - name: Run Ameba static code analysis
         run: ./bin/ameba
 
       - name: Run tests

--- a/README.md
+++ b/README.md
@@ -20,11 +20,9 @@ Run `shards install`
 
 ## 🎬 Screencast
 
-<div style="width:50%">
-  <a href="https://luckycasts.com/videos/decorator-shard"><img src="https://i.imgur.com/1gs4z0c.jpg" title="Decorating Lucky Apps with the Decorator Shard" /></a>
-</div>
+<a href="https://luckycasts.com/videos/decorator-shard"><img src="https://i.imgur.com/1gs4z0c.jpg" title="Decorating Lucky Apps with the Decorator Shard" width="500" /></a>
 
-[Watch Screencast](https://luckycasts.com/videos/decorator-shard)
+[Watch a LuckyCast on the Decorator shard](https://luckycasts.com/videos/decorator-shard)
 
 ## Usage
 
@@ -34,10 +32,10 @@ Require the shard:
 require "decorator"
 ```
 
-Create a decorator that inherits from Decorator::Base, and tell the decorator what it `decorates` to decorate:
+Create a decorator `Struct` that inherits from `Decorator::Base`, and define what it `decorates`:
 
 ```crystal
-class TimeDecorator < Decorator::Base
+struct TimeDecorator < Decorator::Base
   decorates time : Time
 
   # Return a pretty version of a date and weekday in the format:
@@ -54,7 +52,7 @@ class TimeDecorator < Decorator::Base
 end
 ```
 
-In the above example, `Decorator` adds the following to the `TimeDecorator` class for you:
+In the above example, `Decorator` adds the following to the `TimeDecorator` struct for you:
 
 - An `initialize(@time : Time)` method
 - A `getter` (or `getter?` for `Bool` types) for `@time`

--- a/shard.yml
+++ b/shard.yml
@@ -1,6 +1,6 @@
 name: decorator
 description: A simple object decoration library for Crystal apps
-version: 0.3.0
+version: 1.0.0
 
 authors:
   - Stephen Dolan <stephen@luckycasts.com>

--- a/spec/decorator_spec.cr
+++ b/spec/decorator_spec.cr
@@ -14,7 +14,7 @@ class User
   end
 end
 
-class UserDecorator < Decorator::Base
+struct UserDecorator < Decorator::Base
   decorates user : User
 
   def full_name

--- a/src/decorator.cr
+++ b/src/decorator.cr
@@ -2,4 +2,5 @@ require "./decorator/*"
 
 # Decorator provides a simple interface to decorate an object with additional functionality.
 module Decorator
+  VERSION = {{ `shards version "#{__DIR__}"`.chomp.stringify }}
 end

--- a/src/decorator/base.cr
+++ b/src/decorator/base.cr
@@ -1,4 +1,4 @@
-class Decorator::Base
+abstract struct Decorator::Base
   # Keep track of how many `decorates` statements have been provided so that we can limit to 1.
   macro inherited
     DECORATOR_ASSIGNS = [] of Nil
@@ -8,15 +8,15 @@ class Decorator::Base
   #
   # Currently, you can only supply **one** `decorates` statement per decorator that inherits from `Decorator::Base`.
   #
-  # Given a decorator class like this:
+  # Given a decorator struct like this:
   #
   # ```
-  # class TimeDecorator < Decorator::Base
+  # struct TimeDecorator < Decorator::Base
   #   decorates time : Time
   # end
   # ```
   #
-  # The following items are made available to the `TimeDecorator` class:
+  # The following items are made available to the `TimeDecorator` struct:
   #
   # - An `initialize(@time : Time)` method
   # - A `getter` (or `getter?` for `Bool` types) for `@time`

--- a/src/decorator/version.cr
+++ b/src/decorator/version.cr
@@ -1,3 +1,0 @@
-module Decorator
-  VERSION = {{ `shards version "#{__DIR__}"`.chomp.stringify }}
-end


### PR DESCRIPTION
- Closes #1 by implementing `Struct` instead of classes, per recommendation by @straight-shoota here: https://forum.crystal-lang.org/t/screencast-using-the-decorator-design-pattern-to-simplify-time-object-presentations/2880/4?u=stephendolan
- Establish better documentation release workflow that only triggers on tag creation, and appropriately sets the project name and version
- Move from container-based workflow tests to the install-crystal GitHub action
- Go ahead and bump the version to 1.0.0 to prep for a post-merge release